### PR TITLE
Updating lastmod date string format to match W3C spec

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ function SitemapWebpackPlugin(base, paths, fileName) {
 }
 
 function GenerateDate() {
-  var date = new Date().toLocaleDateString().split("/");
+  var dateOptions = { day: '2-digit', month: '2-digit', year: 'numeric' };
+  var date = new Date().toLocaleDateString([], dateOptions).split("/");
   var year = date.splice(-1)[0];
   date.splice(0, 0, year);
   var formattedDate = date.join("-");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sitemap-webpack-plugin",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Webpack plugin to generate a sitemap.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Issue
The `lastUpdate` value sets single digit day and month values.  For example, today would be `2017-1-3` in the xml sitemap output.  This causes sitemaps to be invalid on certain search engines, such as Google.

## Solution
The [sitemaps.org protocol](https://www.sitemaps.org/protocol.html) mentions that the `<lastmod>` tag should work as such:
> The date of last modification of the file. This date should be in [W3C Datetime](https://www.w3.org/TR/NOTE-datetime) format. This format allows you to omit the time portion, if desired, and use YYYY-MM-DD.

## Description
- Change just adds options to the `GenerateDate` function's call to `toLocaleDateString` that should output the correct, Goolge-friendly format now. 😄 