### PR TITLE
More realistic generation failure test for malformed base URL

### DIFF
--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -1,23 +1,29 @@
 import webpack from "webpack";
 import webpackConfig from "./cases/basic/webpack.config";
-import * as generators from "../src/generators";
+import SitemapPlugin from "../src";
 import * as helpers from "../src/helpers";
 
 describe("Errors", () => {
-  it("reports generation error", done => {
-    const spy = jest
-      .spyOn(generators, "generateSitemaps")
-      .mockImplementation(() => {
-        throw new Error("a generation error happened");
-      });
-
-    webpack(webpackConfig, (_err, output) => {
-      expect(output?.compilation?.errors[0]).toEqual(
-        expect.stringContaining("Error: a generation error happened")
-      );
-      spy.mockRestore();
-      done();
-    });
+  it("reports generation error from malformed base URL", done => {
+    webpack(
+      {
+        ...webpackConfig,
+        plugins: [
+          new SitemapPlugin({
+            base: "example.com",
+            paths: ["/", "/about"]
+          })
+        ]
+      },
+      (_err, output) => {
+        expect(output?.compilation?.errors[0]).toEqual(
+          expect.stringContaining(
+            "TypeError [ERR_INVALID_URL]: Invalid URL: example.com"
+          )
+        );
+        done();
+      }
+    );
   });
 
   it("reports gzip error", done => {


### PR DESCRIPTION
This is a real case that can happen, so prefer that over testing a contrived mocked error.