### PR TITLE
Relax test for invalid URL error message

### DIFF
--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -17,9 +17,7 @@ describe("Errors", () => {
       },
       (_err, output) => {
         expect(output?.compilation?.errors[0]).toEqual(
-          expect.stringContaining(
-            "TypeError [ERR_INVALID_URL]: Invalid URL: example.com"
-          )
+          expect.stringContaining("TypeError [ERR_INVALID_URL]: Invalid URL")
         );
         done();
       }


### PR DESCRIPTION
Seems like the latest Node version doesn't repeat back the URL in its error message.