### PR TITLE
Account for emitAsset not being available in webpack 4 pre-4.40

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ jobs:
             yarn install
             cd test/webpack-3 && yarn install
             cd ../webpack-4 && yarn install
+            cd ../webpack-4-0 && yarn install
             cd ../webpack-5 && yarn install
       - save_cache:
           key: dependency-cache-{{ checksum "yarn.lock" }}-v1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sitemap-webpack-plugin",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Webpack plugin to generate a sitemap.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -42,6 +42,19 @@ export function compilationPublicPath(compilation: Compilation): string {
   }
 }
 
+// Helper function to emit an asset to a compilation through either the old or new API.
+export function compilationEmitAsset(
+  compilation: Compilation,
+  file: string,
+  source: sources.Source
+): void {
+  if (compilation.emitAsset) {
+    compilation.emitAsset(file, source);
+  } else {
+    compilation.assets[file] = source;
+  }
+}
+
 // Helper to return an object of attributes combining path and global options.
 export function pathAttributes(
   path: Path,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,10 @@
 import { JSONSchema7 } from "json-schema";
 import { validate } from "schema-utils";
-import { Compiler, Compilation } from "webpack";
+import { Compiler, Compilation, sources } from "webpack";
 import { generateSitemaps } from "./generators";
 import {
   RawSource,
+  compilationEmitAsset,
   compilationPublicPath,
   gzip,
   assertValidChangefreq,
@@ -84,7 +85,8 @@ export default class SitemapWebpackPlugin {
       );
 
       sitemaps.forEach((sitemap, idx) => {
-        compilation.emitAsset(
+        compilationEmitAsset(
+          compilation,
           sitemapFilename(this.filename, "xml", idx),
           new RawSource(sitemap, false)
         );
@@ -106,7 +108,8 @@ export default class SitemapWebpackPlugin {
       const sitemap = sitemaps[idx];
       try {
         const compressed = await gzip(sitemap);
-        compilation.emitAsset(
+        compilationEmitAsset(
+          compilation,
           sitemapFilename(this.filename, "xml.gz", idx),
           new RawSource(compressed, false)
         );

--- a/test/webpack-4-0/index.test.ts
+++ b/test/webpack-4-0/index.test.ts
@@ -1,0 +1,6 @@
+import webpack from "webpack";
+import generateCases from "../utils/cases";
+
+describe("webpack 4.0", () => {
+  generateCases(webpack);
+});

--- a/test/webpack-4-0/package.json
+++ b/test/webpack-4-0/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "webpack-4-0",
+  "private": true,
+  "dependencies": {
+    "webpack": "4.0.0"
+  }
+}


### PR DESCRIPTION
`compilation.emitAsset` wasn't available in webpack 4 prior to 4.40; if it doesn't exist, fall back to assigning the source directly to `compilation.assets`